### PR TITLE
fix: func start not using https when launch

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -51,13 +51,11 @@
 		// Configure properties specific to VS Code.
 		"vscode": {
 			"settings": {
-                "workbench.colorTheme": "Visual Studio 2019 Dark",
 				"terminal.integrated.defaultProfile.linux": "zsh",
                 "editor.formatOnPaste": true,
 
 				"editor.guides.bracketPairs": "active",
 
-                "scm.defaultViewMode": "tree",
                 "debug.internalConsoleOptions": "neverOpen",
 
 				"files.watcherExclude": {
@@ -86,8 +84,6 @@
 			},
 			// Add the IDs of extensions you want installed when the container is created.
 			"extensions": [
-				"github.vscode-pull-request-github",
-
 				"visualstudioexptteam.vscodeintellicode",
 				"visualstudiotxptteam.vscodeintellicode-completions",
 				"ms-dotnettools.csharp",

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -4,17 +4,25 @@
         {
             "label": "clean",
             "command": "dotnet",
-            "args": ["clean", "/property:GenerateFullPaths=true", "/consoleloggerparameters:NoSummary"],
+            "args": [
+                "clean",
+                "/property:GenerateFullPaths=true",
+                "/consoleloggerparameters:NoSummary"
+            ],
             "options": {
                 "cwd": "${workspaceFolder}/test-project/"
             },
             "type": "process",
-            "problemMatcher": "$msCompile",
+            "problemMatcher": "$msCompile"
         },
         {
             "label": "build",
             "command": "dotnet",
-            "args": ["build", "/property:GenerateFullPaths=true", "/consoleloggerparameters:NoSummary"],
+            "args": [
+                "build",
+                "/property:GenerateFullPaths=true",
+                "/consoleloggerparameters:NoSummary"
+            ],
             "options": {
                 "cwd": "${workspaceFolder}/test-project/"
             },
@@ -24,18 +32,18 @@
                 "isDefault": true
             },
             "type": "process",
-            "problemMatcher": "$msCompile",
+            "problemMatcher": "$msCompile"
         },
         {
-            "command": "start",
-            "args": ["--useHttps"],
+            "label": "start",
+            "command": "start --port 7071 --useHttps",
             "options": {
                 "cwd": "${workspaceFolder}/test-project/bin/Debug/net6.0"
             },
             "dependsOn": "build",
-            "type":"func",
+            "type": "func",
             "problemMatcher": "$func-dotnet-watch",
             "isBackground": true
-        },
+        }
     ]
 }

--- a/README.md
+++ b/README.md
@@ -61,8 +61,8 @@ With VS Code:
 
    ```bash
    func init test-project \
-             worker-runtime dotnet-isolated \
-             target-framework net6.0 \
+             --worker-runtime dotnet-isolated \
+             --target-framework net6.0 \
              && cd test-project
    ```
 
@@ -84,7 +84,8 @@ With VS Code:
 
 1. Press `F5` to start the functions app project and call the function. The terminal displays the output from the Core Tools.
 2. When the function executes locally, a notification is raised in VS Code to spin up your favorite browser.
-3. Press `Ctrl+C` to stop Core Tools and disconnect the debugger.
+3. Visit https://localhost:7071/api/httpexample
+4. Press `Ctrl+C` to stop Core Tools and disconnect the debugger.
 
 
 
@@ -128,7 +129,7 @@ If you have any technical problems with GitHub Codespaces or dev containers, you
 
 ## Contributing
 
-The official repo to contribute would be [@microsoft/vscode-dev-containers][contrib-official-repo]. 
+The official repo to contribute would be [@microsoft/vscode-dev-containers][contrib-official-repo].
 
 Have a suggestion or a bug fix? Just open a pull request or an issue. Include the development container with clear and simplest instructions possible.
 


### PR DESCRIPTION
this changeset is to fix the launch tasks to support https on a specific port.

- fix the start task command to use https and port args
- format documents
- update docs with correct commands
- improve docs with developer guides and things to try
- remove unwanted extensions from the container